### PR TITLE
Revert recent changes to async-from-sync iterator

### DIFF
--- a/spec/iteration.html
+++ b/spec/iteration.html
@@ -84,13 +84,12 @@
     <emu-clause id="sec-async-iterator-value-unwrap-functions">
       <h1>Async Iterator Value Unwrap Functions</h1>
 
-      <p>An async iterator value unwrap function is an anonymous built-in function that is used when processing the `value` field of an <i>IteratorResult</i> object, in order to wait for its value if it is a promise and re-package the result in a new "unwrapped" <i>IteratorResult</i> object that is then used to resolve the relevant promise. Each async iterator value unwrap function has [[Done]] and [[PromiseCapability]] internal slots.</p>
+      <p>An async iterator value unwrap function is an anonymous built-in function that is used when processing the `value` field of an <i>IteratorResult</i> object, in order to wait for its value if it is a promise and re-package the result in a new "unwrapped" <i>IteratorResult</i> object. Each async iterator value unwrap function has a [[Done]] internal slot.</p>
 
       <p>When an async iterator unwrap function _F_ is called with argument _value_, the following steps are taken:</p>
 
       <emu-alg>
-        1. Let _result_ be ! CreateIterResultObject(_value_, _F_.[[Done]]).
-        1. Perform ! Call(_F_.[[PromiseCapability]].[[Resolve]], *undefined*, &laquo; _result_ &raquo;).
+        1. Return ! CreateIterResultObject(_value_, _F_.[[Done]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -152,8 +151,7 @@
         1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _nextValue_ &raquo;).
         1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#sec-async-iterator-value-unwrap-functions" title></emu-xref>.
         1. Set _onFulfilled_.[[Done]] to _nextDone_.
-        1. Set _onFulfilled_.[[PromiseCapability]] to _promiseCapability_.
-        1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, _promiseCapability_.[[Reject]], _promiseCapability_).
+        1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
         1. Return _promiseCapability_.[[Promise]].
       </emu-alg>
     </emu-clause>
@@ -185,8 +183,7 @@
         1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _returnValue_ &raquo;).
         1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#sec-async-iterator-value-unwrap-functions" title></emu-xref>.
         1. Set _onFulfilled_.[[Done]] to _returnDone_.
-        1. Set _onFulfilled_.[[PromiseCapability]] to _promiseCapability_.
-        1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, _promiseCapability_.[[Reject]], _promiseCapability_).
+        1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
         1. Return _promiseCapability_.[[Promise]].
       </emu-alg>
     </emu-clause>
@@ -217,8 +214,7 @@
         1. Perform ! Call(_valueWrapperCapability_.[[Resolve]], *undefined*, &laquo; _throwValue_ &raquo;).
         1. Let _onFulfilled_ be a new built-in function object as defined in <emu-xref href="#sec-async-iterator-value-unwrap-functions" title></emu-xref>.
         1. Set _onFulfilled_.[[Done]] to _throwDone_.
-        1. Set _onFulfilled_.[[PromiseCapability]] to _promiseCapability_.
-        1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, _promiseCapability_.[[Reject]], _promiseCapability_).
+        1. Perform ! PerformPromiseThen(_valueWrapperCapability_.[[Promise]], _onFulfilled_, *undefined*, _promiseCapability_).
         1. Return _promiseCapability_.[[Promise]].
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
The commits e544dc869d0c2122d81a32dcdc40cb42ee7db3ed and 7bd31a53d3a33f2e50876a4cb206e4457b631685 were incorrect. They were based on forgetting that PerformPromiseThen will use its last argument as the result capability.

Closes #73, which is a product of this confusion.

@caitp, @GeorgNeis, mind checking this?