### PR TITLE
Create a special version of IteratorClose for async iterators

### DIFF
--- a/spec/generator-definitions-patch.html
+++ b/spec/generator-definitions-patch.html
@@ -31,9 +31,9 @@
           1. Let _received_ be GeneratorYield(_innerResult_).
         1. Else,
           1. NOTE: If _iterator_ does not have a `throw` method, this throw is going to terminate the `yield*` loop. But first we need to give _iterator_ a chance to clean up.
-          1. <ins>Let _closeResult_ be</ins><del>Perform</del> ? IteratorClose(_iterator_, Completion{[[Type]]: ~normal~, [[Value]]: ~empty~, [[Target]]: ~empty~}).
-          1. <ins>If _generatorKind_ is ~async~, set _closeResult_ to Await(_closeResult_).</ins>
-          1. <ins>ReturnIfAbrupt(_closeResult_).</ins>
+          1. <ins>Let _closeCompletion_ be Completion{[[Type]]: ~normal~, [[Value]]: ~empty~, [[Target]]: ~empty~}.</ins>
+          1. <ins>If _generatorKind_ is ~async~, perform ? AsyncIteratorClose(_iterator_, _closeCompletion_).</ins>
+          1. Perform ? IteratorClose(_iterator_, <del>Completion{[[Type]]: ~normal~, [[Value]]: ~empty~, [[Target]]: ~empty~}</del><ins>_closeCompletion_</ins>).
           1. NOTE: The next step throws a *TypeError* to indicate that there was a `yield*` protocol violation: _iterator_ does not have a `throw` method.
           1. Throw a *TypeError* exception.
       1. Else,

--- a/spec/iteration-statements-patch.html
+++ b/spec/iteration-statements-patch.html
@@ -416,15 +416,14 @@
             1. Let _status_ be the result of performing BindingInitialization for _lhs_ passing _nextValue_ and _iterationEnv_ as arguments.
         1. If _status_ is an abrupt completion, then
           1. Set the running execution context's LexicalEnvironment to _oldEnv_.
-          1. <ins>Let _closeResult_ be</ins><del>Return</del> ? IteratorClose(_iterator_, _status_).
-          1. <ins>If _iteratorKind_ is ~async~, set _closeResult_ to Await(_closeResult_).</ins>
-          1. <ins>Return _closeResult_.</ins>
+          1. <ins>If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iterator_, _status_).</ins>
+          1. Return ? IteratorClose(_iterator_, _status_).
         1. Let _result_ be the result of evaluating _stmt_.
         1. Set the running execution context's LexicalEnvironment to _oldEnv_.
         1. If ! LoopContinues(_result_, _labelSet_) is *false*, <del>return ? IteratorClose(_iterator_, UpdateEmpty(_result_, _V_))</del><ins>then</ins>
-          1. <ins>Let _closeResult_ be ? IteratorClose(_iterator_, UpdateEmpty(_result_, _V_)).</ins>
-          1. <ins>If _iteratorKind_ is ~async~, set _closeResult_ to Await(_closeResult_).</ins>
-          1. <ins>Return _closeResult_.</ins>
+          1. <ins>Let _status_ be UpdateEmpty(_result_, _V_).</ins>
+          1. <ins>If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iterator_, _status_).</ins>
+          1. <ins>Return ? IteratorClose(_iterator_, _status_).</ins>
         1. If _result_.[[Value]] is not ~empty~, let _V_ be _result_.[[Value]].
     </emu-alg>
   </emu-clause>

--- a/spec/iterator-operations.html
+++ b/spec/iterator-operations.html
@@ -21,3 +21,20 @@
     1. Return _iterator_.
   </emu-alg>
 </emu-clause>
+
+<emu-clause id="sec-asynciteratorclose" aoid="AsyncIteratorClose">
+  <h1><ins>AsyncIteratorClose ( _iterator_, _completion_ )</ins></h1>
+  <p>The abstract operation AsyncIteratorClose with arguments _iterator_ and _completion_ is used to notify an async iterator that it should perform any actions it would normally perform when it has reached its completed state:</p>
+  <emu-alg>
+    1. Assert: Type(_iterator_) is Object.
+    1. Assert: _completion_ is a Completion Record.
+    1. Let _return_ be ? GetMethod(_iterator_, `"return"`).
+    1. If _return_ is *undefined*, return Completion(_completion_).
+    1. Let _innerResult_ be Call(_return_, _iterator_, &laquo; &raquo;).
+    1. If _innerResult_.[[Type]] is ~normal~, set _innerResult_ to Await(_innerResult_.[[Value]]).
+    1. If _completion_.[[Type]] is ~throw~, return Completion(_completion_).
+    1. If _innerResult_.[[Type]] is ~throw~, return Completion(_innerResult_).
+    1. If Type(_innerResult_.[[Value]]) is not Object, throw a *TypeError* exception.
+    1. Return Completion(_completion_).
+  </emu-alg>
+</emu-clause>


### PR DESCRIPTION
Because IteratorClose never returns the actual return value of the return() method, the previous tactic of Await()ing the return value of IteratorClose() is not correct. Instead, we need AsyncIteratorClose(), which itself properly Await()s the return value of the return() method.

Fixes #72.

@GeorgNeis @caitp review welcome.