### PR TITLE
flag optional BindingIdentifier on AG Expression

### DIFF
--- a/spec/definitions.html
+++ b/spec/definitions.html
@@ -8,7 +8,7 @@
     [+Default] `async` [no LineTerminator here] `function` `*` `(` FormalParameters[+Yield, +Await] `)` `{` AsyncGeneratorBody `}`
 
   AsyncGeneratorExpression :
-    `async` [no LineTerminator here] `function` `*` BindingIdentifier[+Yield, +Await] `(` FormalParameters[+Yield, +Await] `)` `{` AsyncGeneratorBody `}`
+    `async` [no LineTerminator here] `function` `*` BindingIdentifier[+Yield, +Await]? `(` FormalParameters[+Yield, +Await] `)` `{` AsyncGeneratorBody `}`
 
   AsyncGeneratorBody :
     FunctionBody[+Yield, +Await]


### PR DESCRIPTION
Fixes #95 


cc @domenic, it's easier to write this patch to show the exact part I'm asking on #95.

Considering your feedback, I believe this optional flag is missing here.

ref: [GeneratorExpression](https://tc39.github.io/ecma262/#prod-GeneratorExpression)