### PR TITLE
add for-await-of desugared example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ for await (const line of readLines(filePath)) {
 }
 ```
 
+This is equivalent to:
+
+```js
+for (const _ of readLines(filePath)) {
+  const line = await _;
+  console.log(line);
+}
+```
+
 Async for-of statements are only allowed within async functions and async generator functions (see below for the latter).
 
 During execution, an async iterator is created from the data source using the `[Symbol.asyncIterator]()` method.


### PR DESCRIPTION
This may be obvious to everyone involved, but can we include the following desugared example in the readme, if correct?

---

Original example:

```js
for await (const line of readLines(filePath)) {
  console.log(line);
}
```

Equivalent to:

```js
for (const _ of readLines(filePath)) {
  const line = await _;
  console.log(line);
}
```
