### PR TITLE
add (corrected) for-await-of equivalent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ for await (const line of readLines(filePath)) {
 }
 ```
 
+This is equivalent to:
+
+```js
+for (const _ of readLines(filePath)) {
+  const line = await _;
+  console.log(line);
+}
+```
+
 Async for-of statements are only allowed within async functions and async generator functions (see below for the latter).
 
 During execution, an async iterator is created from the data source using the `[Symbol.asyncIterator]()` method.

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ for await (const line of readLines(filePath)) {
 This is equivalent to:
 
 ```js
-for (const _ of readLines(filePath)) {
-  const line = await _;
-  console.log(line);
+const i = readLines(filePath);
+while (true) {
+  const {value, done} = await i.next();
+  if (done) break;
+  console.log(value);
 }
 ```
 


### PR DESCRIPTION
Fixed #128 if the correct translated example is desired:

---

Original example:

```js
for await (const line of readLines(filePath)) {
  console.log(line);
}
```

Equivalent to:

```js
const i = readLines(filePath);
while (true) {
  const {value, done} = await i.next();
  if (done) break;
  console.log(value);
}
```